### PR TITLE
edit asw.sql file

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,30 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="@localhost" uuid="a08b4fcb-3691-490e-9917-f741a9e85f1c">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="asw@localhost" uuid="b94a448d-3c8e-4c2d-a310-637d14e93402">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <remarks>예소 테스트</remarks>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/asw</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourcePerFileMappings">
+    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/b94a448d-3c8e-4c2d-a310-637d14e93402/console.sql" value="b94a448d-3c8e-4c2d-a310-637d14e93402" />
+    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/f308d5f0-d83b-4419-9ac3-aca90f9df1b7/console.sql" value="f308d5f0-d83b-4419-9ac3-aca90f9df1b7" />
+    <file url="file://$PROJECT_DIR$/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/asw.sql" value="b94a448d-3c8e-4c2d-a310-637d14e93402" />
     <file url="file://$PROJECT_DIR$/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/test.sql" value="f308d5f0-d83b-4419-9ac3-aca90f9df1b7" />
   </component>
 </project>

--- a/.idea/sqlDataSources.xml
+++ b/.idea/sqlDataSources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDataSourceStorage">
+    <option name="dataSources">
+      <list>
+        <State>
+          <option name="id" value="98e23c51-6c31-4939-88b1-fbfa58ee2956" />
+          <option name="name" value="asw@localhost (DDL)" />
+          <option name="dbmsName" value="MYSQL" />
+          <option name="urls">
+            <array />
+          </option>
+          <option name="outLayout" value="File per object by schema.groovy" />
+        </State>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/asw.sql" dialect="MySQL" />
     <file url="file://$PROJECT_DIR$/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/test.sql" dialect="MySQL" />
   </component>
 </project>

--- a/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/asw.sql
+++ b/artificialsw-backend/src/main/java/org/dcode/artificialswbackend/db/asw.sql
@@ -1,2 +1,74 @@
 USE asw;
 
+-- families 테이블
+
+-- users 테이블
+
+-- questions 테이블
+
+-- public_questions 테이블
+
+-- question_reference 테이블
+
+-- comments 테이블 (family_id 컬럼 추가)
+
+-- question_list 테이블 (family_id 포함하지 않음, 관리용)
+
+-- flower_catalog 테이블 (family_id 불필요)
+
+-- fruit_catalog 테이블 (family_id 불필요)
+
+-- archives 테이블 (멀티 테넌트 용 family_id 포함)
+
+-- tree 테이블 (멀티 테넌트 용 family_id 포함)
+
+-- flowers 테이블 (tree_id 통해 family_id 간접관리)
+
+-- fruits 테이블 (tree_id 통해 family_id 간접관리)
+
+-- custom_tree_featured_items 테이블 (tree_id 통해 family_id 간접관리) - 삭제할거임
+
+-- puzzle 테이블 (멀티 테넌트 용 family_id 포함)) - puzzle 아카이브로 만들어야겠네.....
+
+-- puzzle_category 테이블 (puzzle_id 통해 family_id 간접관리)
+
+-- puzzle_ai_keyword 테이블 (puzzle_id 통해 family_id 간접관리)
+
+-- puzzle_pieces 테이블
+
+
+
+DELIMITER //
+
+CREATE TRIGGER trg_after_insert_questions
+    AFTER INSERT ON questions
+    FOR EACH ROW
+BEGIN
+    INSERT INTO question_reference (question_id, question_type, family_id)
+    VALUES (NEW.id, 'personal', NEW.family_id);
+END;
+//
+
+CREATE TRIGGER trg_after_insert_public_questions
+    AFTER INSERT ON public_questions
+    FOR EACH ROW
+BEGIN
+    INSERT INTO question_reference (question_id, question_type, family_id)
+    VALUES (NEW.id, 'public', NEW.family_id);
+END;
+//
+
+CREATE TRIGGER trg_before_insert_comments
+    BEFORE INSERT ON comments
+    FOR EACH ROW
+BEGIN
+    DECLARE ref_family_id BIGINT;
+    SELECT family_id INTO ref_family_id
+    FROM question_reference
+    WHERE id = NEW.question_ref_id
+    LIMIT 1;
+    SET NEW.family_id = ref_family_id;
+END;
+//
+
+DELIMITER ;


### PR DESCRIPTION
- 사전
	- ai 서버에서 해당 꽃에서의 태그로 판별(생성)된 최초의 부착물을 표시해줌
	- 기존 : 해당 부착물이 어떤 질문때문에 생성됐는지를 명시했어야 했음
	- 현재 : 표시할 필요 X. 독립적인 테이블이어도 됨
		- `flower` 테이블에서 `fk`로 존재하는 `flower_catalog_id`를 삭제 
		- `flower_catalog` 테이블에서 필요한 column
			- 이건 해금된 정보만 보내주면 프론트에 해줄 수 있지 않나?
			- 할 수 있다고 하면 unlocked 만 있으면 됨.
				- `name`, `keyword` 삭제
		- `fruit` 테이블도 마찬가지
- 커스텀 나무 삭제
- `fruits` column 수정
	- 퍼즐 -> 과일 생성
	- `question_id` 삭제 후 `puzzle_id` 추가
		- 이거 그냥 id 로 바꿔야할 듯
- `tree` 테이블 수정
	- ![[Pasted image 20250922015720.png|300]]
	- 지금의 구조로는 하나의 나무만 관리할 수 있음.
	- `name`, `display_order`, 삭제
	-  한 아카이브에 나무가 4개여야함
		- 아카이브가 `fk` 로 존재해서 굳이 나눌 필요는 없을 듯
	- 9.21 회의 적용 후
		- 방안 1 -> 이게 좋을 듯
			- 열매, 꽃 나무 두개의 테이블을 생성 후 그냥 만들고 생성 시간을 보고 로직으로 반환을 따로함 -> `tree_category` 에서 enum 으로 `flower` , `fruit` 를 나누는 걸로 해봄
- `archives` 테이블 수정

| id  | family_id | month | year | period | created_at |
| --- | --------- | ----- | ---- | ------ | ---------- |
| 1   | 2         | 9     | 2025 | 1      | ...        |
| 2   | 2         | 9     | 2025 | 2      | ...        |
- 이렇게 하면 같은 달(month)에서 두 레코드를 전후반기로 구분해 저장 가능
	-  period 컬럼
	- `int` 타입으로 1, 2 -‘1’은 전반기, ‘2’는 후반기


- `question` 테이블 수정
	- 이름을 `personal_question` 으로 수정
	- 공개여부 (자물쇠) 관련 컬럼인 `isPublic` -> `visibility` 로 수정